### PR TITLE
Parser types fix + ADT, rec, pattern matching in infer

### DIFF
--- a/OcamlADT/lib/inferTypes.ml
+++ b/OcamlADT/lib/inferTypes.ml
@@ -51,14 +51,14 @@ let rec pprint_type_tuple fmt = function
      | _ -> fprintf fmt "%a * %a" pprint_type h pprint_type_tuple tl)
 
 and pprint_type fmt = function
-  | Type_var num -> fprintf fmt "'%c" (Stdlib.Char.chr (Stdlib.Char.code num.[0] + 49))
+  | Type_var num -> fprintf fmt "'%s" num (*(*(Stdlib.Char.chr)*)(Stdlib.Char.code num.[0]) (**)*)
   (* | Type_prim str -> fprintf fmt "%s" str *)
   | Type_arrow (ty1, ty2) ->
     (match ty1, ty2 with
      | Type_arrow (_, _), _ -> fprintf fmt "(%a) -> %a" pprint_type ty1 pprint_type ty2
-     | _ -> fprintf fmt "%a-> %a" pprint_type ty1 pprint_type ty2)
+     | _ -> fprintf fmt "%a -> %a" pprint_type ty1 pprint_type ty2)
   | Type_tuple (t1, t2, ty_lst) -> fprintf fmt "%a" pprint_type_tuple (t1 :: t2 :: ty_lst)
-  | Type_construct (name, ty_list) -> fprintf fmt "%s %a" name pprint_type_tuple ty_list
+  | Type_construct (name,ty_list) -> fprintf fmt "%a%s"  pprint_type_tuple (ty_list) name
 ;;
 
 (* | Type_list ty1 -> fprintf fmt "%a list" pprint_type ty1 *)

--- a/OcamlADT/lib/inferTypes.ml
+++ b/OcamlADT/lib/inferTypes.ml
@@ -58,7 +58,9 @@ and pprint_type fmt = function
      | Type_arrow (_, _), _ -> fprintf fmt "(%a) -> %a" pprint_type ty1 pprint_type ty2
      | _ -> fprintf fmt "%a -> %a" pprint_type ty1 pprint_type ty2)
   | Type_tuple (t1, t2, ty_lst) -> fprintf fmt "%a" pprint_type_tuple (t1 :: t2 :: ty_lst)
-  | Type_construct (name,ty_list) -> fprintf fmt "%a%s"  pprint_type_tuple (ty_list) name
+  | Type_construct (name,[]) -> fprintf fmt "%s" name
+  | Type_construct (name,ty_list) -> fprintf fmt "%a %s"  pprint_type_tuple (ty_list) name
+  
 ;;
 
 (* | Type_list ty1 -> fprintf fmt "%a list" pprint_type ty1 *)

--- a/OcamlADT/tests/dune
+++ b/OcamlADT/tests/dune
@@ -28,6 +28,7 @@
   manytests/typed/007order.ml
   manytests/typed/008ascription.ml
   manytests/typed/009let_poly.ml
-  manytests/typed/010sukharev.ml
-  manytests/typed/015tuples.ml
-  manytests/typed/016lists.ml))
+  ; manytests/typed/010sukharev.ml
+  ; manytests/typed/015tuples.ml
+  ; manytests/typed/016lists.ml
+  ))

--- a/OcamlADT/tests/infer.ml
+++ b/OcamlADT/tests/infer.ml
@@ -69,11 +69,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": 'a-> 'a
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": '0 -> '0
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -82,30 +82,28 @@ let%expect_test "zero" =
     Unbound_variable: "x" |}]
 ;;
 
-(*BUG*)
 let%expect_test "zero" =
   parse_and_infer_result {|let f x = x+x;;|};
   [%expect
     {|
     res:
-    "f":  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
-(*BUG*)
 let%expect_test "zero" =
   parse_and_infer_result {|5+5;;|};
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -113,11 +111,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -125,11 +123,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -137,11 +135,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -149,11 +147,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -161,11 +159,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -173,11 +171,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -185,11 +183,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -198,8 +196,13 @@ let%expect_test "zero" =
 let homka = Some id in
 match homka with
 | Some f -> f 42, f "42";;|};
-  [%expect {|
-    Unification_failed:  int #  string |}]
+  [%expect{|
+    res:
+    "-": int * string
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -208,8 +211,13 @@ let%expect_test "zero" =
 let homkaOBOLTUS = id in
 match homkaOBOLTUS with
 |  f -> f 42, f "42";;|};
-  [%expect {|
-    Unification_failed:  int #  string |}]
+  [%expect{|
+    res:
+    "-": int * string
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -218,8 +226,8 @@ let%expect_test "zero" =
   let homkaOBOLTIMUSPRIME = id in
   match homkaOBOLTIMUSPRIME with
   |  f -> f 42, f "42";;|};
-  [%expect {|
-    Unification_failed:  int #  string |}]
+  [%expect{|
+    Unification_failed: int # string |}]
 ;;
 
 (*BUG*)
@@ -231,14 +239,14 @@ let z = 3;;
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  int
-    "y":  int
-    "z":  int |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int
+    "y": int
+    "z": int |}]
 ;;
 
 let%expect_test "zero" =
@@ -246,11 +254,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -258,11 +266,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  string
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": string
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -270,11 +278,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int *  int *  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int * int * int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -285,14 +293,13 @@ let%expect_test "zero" =
 | 68 -> 'h' 
 | 69 -> 's' 
 | 89 -> 'a';;|};
-  [%expect
-    {|
+  [%expect{|
     res:
-    "-":  int->  char
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": char
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -306,14 +313,13 @@ let%expect_test "zero" =
 |7 -> 1
 | _ -> 3
 ;;|};
-  [%expect
-    {|
+  [%expect{|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -321,11 +327,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int->  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int -> int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*ALL "LET" ITEMS*)
@@ -335,11 +341,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "y":  int |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "y": int |}]
 ;;
 
 let%expect_test "zero" =
@@ -347,11 +353,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "y":  string *  string |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "y": string * string |}]
 ;;
 
 let%expect_test "zero" =
@@ -359,12 +365,12 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  int *  int
-    "y":  string *  string |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int * int
+    "y": string * string |}]
 ;;
 
 let%expect_test "zero" =
@@ -372,14 +378,14 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  int
-    "y":  int
-    "z":  string *  string |}]
+    "f": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int
+    "y": int
+    "z": string * string |}]
 ;;
 
 let%expect_test "zero" =
@@ -387,12 +393,12 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  int
-    "y":  char |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int
+    "y": char |}]
 ;;
 
 let%expect_test "zero" =
@@ -400,11 +406,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  bool |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": bool |}]
 ;;
 
 let%expect_test "zero" =
@@ -412,11 +418,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -424,11 +430,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f": 'b-> 'c
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": [ 1; 2; ]. '1 -> '2
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -436,11 +442,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f": [ 0; ]. 'a-> 'a
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": [ 0; ]. '0 -> '0
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -450,18 +456,18 @@ let 5 = x;;|};
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "x":  int |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int |}]
 ;;
 
 let%expect_test "zero" =
   parse_and_infer_result {|
 let x = (6: char);;|};
   [%expect {|
-    Unification_failed:  int #  char |}]
+    Unification_failed: int # char |}]
 ;;
 
 let%expect_test "zero" =
@@ -470,14 +476,13 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-":  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "-": bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
-(*bug*)
 let%expect_test "zero" =
   parse_and_infer_result
     {|
@@ -486,15 +491,14 @@ let id = fun x -> x in (id square) (id 123);;|};
   [%expect
     {|
     res:
-    "-":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "square":  int->  int |}]
+    "-": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "square": int -> int |}]
 ;;
 
-(*BUG*)
 let%expect_test "zero" =
   parse_and_infer_result
     {|
@@ -504,12 +508,12 @@ let rec meven n = if n = 0 then 1 else modd (n - 1)
   [%expect
     {|
     res:
-    "meven":  int->  int
-    "modd":  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "meven": int -> int
+    "modd": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -517,11 +521,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f":  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -529,29 +533,28 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f":  int->  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": int -> int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
   parse_and_infer_result {| let f (x: int) = x || x;;|};
   [%expect {|
-    Unification_failed:  int #  bool |}]
+    Unification_failed: int # bool |}]
 ;;
 
 let%expect_test "zero" =
   parse_and_infer_result {| let f (x: int) = function 5 -> true | 6 -> false;;|};
-  [%expect
-    {|
+  [%expect{|
     res:
-    "f":  int->  int->  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "f": int -> bool
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -559,17 +562,11 @@ let%expect_test "zero" =
   [%expect {|
     Unbound_variable: "f" |}]
 ;;
-
+(*BUG*)
 let%expect_test "zero" =
   parse_and_infer_result {| let (f: int -> bool) = function 5 -> true | 6 -> false;;|};
-  [%expect
-    {|
-    res:
-    "f":  int->  bool
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+  [%expect{|
+    Unification_failed: bool # int -> bool |}]
 ;;
 
 (*KAKADU TYPE BEAT*)
@@ -580,11 +577,11 @@ let rec fac n = if n<=1 then 1 else n * fac (n-1);;|};
   [%expect
     {|
     res:
-    "fac":  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fac": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*passed*)
@@ -598,12 +595,12 @@ let rec fac n = if n<=1 then 1 else n * fac (n-1);;
   [%expect
     {|
     res:
-    "fac":  int->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fac": int -> int
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -615,12 +612,7 @@ let rec fac_cps n k =
   fac_cps (n-1) (fun p -> k (p*n));;|};
   [%expect
     {|
-    res:
-    "fac_cps":  int-> ( int-> 'i) -> 'i
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    Occurs_check |}]
 ;;
 
 (*passed*)
@@ -634,13 +626,7 @@ let rec fac_cps n k =
   0;;|};
   [%expect
     {|
-    res:
-    "fac_cps":  int-> ( int->  int) ->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    Occurs_check |}]
 ;;
 
 (*PASSED*)
@@ -660,12 +646,12 @@ let rec fib_acc a b n =
   [%expect
     {|
     res:
-    "fib":  int->  int
-    "fib_acc":  int->  int->  int->  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fib": int -> int
+    "fib_acc": int -> int -> int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*passed*)
@@ -689,13 +675,13 @@ let rec fib_acc a b n =
   [%expect
     {|
     res:
-    "fib":  int->  int
-    "fib_acc":  int->  int->  int->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fib": int -> int
+    "fib_acc": int -> int -> int -> int
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -723,14 +709,14 @@ let main =
   [%expect
     {|
     res:
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "test10":  int->  int->  int->  int->  int->  int->  int->  int->  int->  int->  int
-    "test3":  int->  int->  int->  int
-    "wrap": [ 0; ]. 'a-> 'a |}]
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "test10": int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int
+    "test3": int -> int -> int -> int
+    "wrap": [ 0; ]. '0 -> '0 |}]
 ;;
 
 (*PASSED*)
@@ -743,12 +729,12 @@ let fac self n = if n<=1 then 1 else n * self (n-1);;|};
   [%expect
     {|
     res:
-    "fac": ( int->  int) ->  int->  int
-    "fix": (('c-> 'f) -> 'c-> 'f) -> 'c-> 'f
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fac": (int -> int) -> int -> int
+    "fix": [ 2; 5; ]. (('2 -> '5) -> '2 -> '5) -> '2 -> '5
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -765,13 +751,13 @@ let main =
   [%expect
     {|
     res:
-    "fac": ( int->  int) ->  int->  int
-    "fix": (( int->  int) ->  int->  int) ->  int->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "fac": (int -> int) -> int -> int
+    "fix": [ 2; 5; ]. (('2 -> '5) -> '2 -> '5) -> '2 -> '5
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED?*)
@@ -785,12 +771,12 @@ let%expect_test "006" =
   [%expect
     {|
     res:
-    "foo":  int->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "foo": int -> int
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -811,12 +797,12 @@ let main =
   [%expect
     {|
     res:
-    "foo":  int->  int->  int->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "foo": int -> int -> int -> int
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -833,12 +819,12 @@ let main =
   [%expect
     {|
     res:
-    "foo":  int->  int->  int->  unit
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "foo": int -> int -> int -> unit
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -854,12 +840,12 @@ let main =
   [%expect
     {|
     res:
-    "_start":  unit->  unit->  int->  unit->  int->  int->  unit->  int->  int->  int
-    "main":  unit
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "_start": unit -> unit -> int -> unit -> int -> int -> unit -> int -> int -> int
+    "main": unit
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -873,12 +859,12 @@ let main =
   [%expect
     {|
     res:
-    "addi": [ 2; ]. ('c->  bool->  int) -> ('c->  bool) -> 'c->  int
-    "main":  int
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit |}]
+    "addi": [ 2; ]. ('2 -> bool -> int) -> ('2 -> bool) -> '2 -> int
+    "main": int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
 
 (*PASSED*)
@@ -890,11 +876,11 @@ let temp =
   [%expect
     {|
     res:
-    "print_bool":  bool->  unit
-    "print_char":  char->  unit
-    "print_endline":  string->  unit
-    "print_int":  int->  unit
-    "temp":  int *  bool |}]
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "temp": int * bool |}]
 ;;
 
 (*FAILED _5*)
@@ -930,9 +916,24 @@ let aaa_5 =
   | None -> 0
 ;;
     |};
-  [%expect {|
-    Unification_failed:  string #  int |}]
+  [%expect{|
+    res:
+    "_1": [ 3; ]. int -> int -> int * '3 -> bool
+    "_2": int
+    "_3": int * stringoption
+    "_4": [ 13; ]. int -> '13
+    "a_42": bool
+    "aaa_5": int
+    "id1": [ 17; 18; ]. '17 -> '17
+    "id2": [ 17; 18; ]. '18 -> '18
+    "int_of_option": int
+    "k_6": [ 31; ]. '31option -> '31
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;
+
 
 (*FAILED *)
 let%expect_test "015" =
@@ -948,9 +949,8 @@ let feven p n =
 let fodd p n =
   let (e, o) = p in
   if n = 0 then 0 else e (n - 1);;
-let tie = fixpoly (feven, fodd);;
-
-let rec meven n = if n = 0 then 1 else modd (n - 1)
+  let tie = fixpoly (feven, fodd);; 
+  let rec meven n = if n = 0 then 1 else modd (n - 1)
 and modd n = if n = 0 then 1 else meven (n - 1);;
 let main =
   let () = print_int (modd 1) in
@@ -958,65 +958,60 @@ let main =
   let (even,odd) = tie in
   let () = print_int (odd 3) in
   let () = print_int (even 4) in
-  0;;|};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Failure aboba)
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_lib__Infer.infer_exp in file "lib/infer.ml", line 410, characters 13-29
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 739, characters 2-40
-  Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 939, characters 2-638
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+  0;;
+|};
+  [%expect{|
+    res:
+    "feven": [ 32; ]. '32 * (int -> int) -> int -> int
+    "fix": [ 2; 5; ]. (('2 -> '5) -> '2 -> '5) -> '2 -> '5
+    "fixpoly": [ 21; 24; ]. (('21 -> '24) * ('21 -> '24) -> '21 -> '24) * (('21 -> '24) * ('21 -> '24) -> '21 -> '24) -> ('21 -> '24) * ('21 -> '24)
+    "fodd": [ 40; ]. (int -> int) * '40 -> int -> int
+    "main": int
+    "map": [ 11; 9; ]. ('9 -> '11) -> '9 * '9 -> '11 * '11
+    "meven": int -> int
+    "modd": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "tie": (int -> int) * (int -> int) |}]
 ;;
 
+  
 (*KAKADU DO NOT TYPE BEAT*)
-
 
 (*PASSED*)
 let%expect_test "001" =
-  parse_and_infer_result
-    {|
+  parse_and_infer_result {|
 let recfac n = if n<=1 then 1 else n * fac (n-1);;|};
-  [%expect{| Unbound_variable: "fac" |}]
+  [%expect {|
+    Unbound_variable: "fac" |}]
 ;;
 
 (*PASSED*)
 let%expect_test "002" =
-  parse_and_infer_result
-    {|
+  parse_and_infer_result {|
 let main = if true then 1 else false;;|};
-  [%expect{| Unification_failed:  int #  bool |}]
+  [%expect {|
+    Unification_failed: int # bool |}]
 ;;
-
 
 (*PASSED*)
 let%expect_test "003  " =
   parse_and_infer_result
     {|
 let fix f = (fun x -> f (fun f -> x x f))  (fun x -> f (fun f -> x x f));;|};
-  [%expect{| Occurs_check |}]
+  [%expect {|
+    Occurs_check |}]
 ;;
 
 (*PASSED*)
 let%expect_test "004  " =
-  parse_and_infer_result
-    {|
+  parse_and_infer_result {|
 let _1 =
   (fun f -> (f 1, f true)) (fun x -> x);;|};
-  [%expect{| Unification_failed:  int #  bool |}]
+  [%expect {|
+    Unification_failed: int # bool |}]
 ;;
 
 (*PASSED*)
@@ -1026,15 +1021,16 @@ let%expect_test "005  " =
 let _2 = function
   | Some f -> let _ = f "42" in f 42
   | None -> 1;;|};
-  [%expect{| Unification_failed:  string #  int |}]
+  [%expect{|
+    Unification_failed: string # int |}]
 ;;
 
 (*PASSED*)
 let%expect_test "015" =
-  parse_and_infer_result
-    {|let rec (a,b) = (a,b);;|};
+  parse_and_infer_result {|let rec (a,b) = (a,b);;|};
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -1044,23 +1040,25 @@ let%expect_test "015" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 739, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 817, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1034, characters 2-56
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1030, characters 2-52
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
+
 (*PASSED*)
 let%expect_test "016" =
-  parse_and_infer_result
-    {|let a, _ = 1, 2, 3;;|};
-  [%expect{| Unification_failed:  int *  int *  int # 'a * 'b |}]
+  parse_and_infer_result {|let a, _ = 1, 2, 3;;|};
+  [%expect {|
+    Unification_failed: int * int * int # '0 * '1 |}]
 ;;
+
 (*FAILED*)
 let%expect_test "091.1" =
-  parse_and_infer_result
-    {|let [a] = (fun x -> x);;|};
+  parse_and_infer_result {|let [a] = (fun x -> x);;|};
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -1068,19 +1066,20 @@ let%expect_test "091.1" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 58, characters 8-25
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1060, characters 2-57
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1058, characters 2-53
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
+
 (*PASSED*)
 let%expect_test "097.2" =
-  parse_and_infer_result
-    {|let () = (fun x -> x);;|};
-  [%expect{| Unification_failed: 'a-> 'a #  unit |}]
+  parse_and_infer_result {|let () = (fun x -> x);;|};
+  [%expect {|
+    Unification_failed: '0 -> '0 # unit |}]
 ;;
+
 (*PASSED*)
 let%expect_test "098" =
-  parse_and_infer_result
-    {|let rec x = x + 1;;|};
+  parse_and_infer_result {|let rec x = x + 1;;|};
   [%expect.unreachable]
 [@@expect.uncaught_exn {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
@@ -1093,16 +1092,17 @@ let%expect_test "098" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 739, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 817, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1082, characters 2-52
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1082, characters 2-48
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
+
 let%expect_test "098" =
-  parse_and_infer_result
-    {|let rec x::[] = [1];;|};
+  parse_and_infer_result {|let rec x::[] = [1];;|};
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -1110,6 +1110,6 @@ let%expect_test "098" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 58, characters 8-25
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1102, characters 2-54
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1102, characters 2-50
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;

--- a/OcamlADT/tests/infer.ml
+++ b/OcamlADT/tests/infer.ml
@@ -70,10 +70,10 @@ let%expect_test "zero" =
     {|
     res:
     "-": 'a-> 'a
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -88,11 +88,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f": int -> int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "f":  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*BUG*)
@@ -101,11 +101,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -113,11 +113,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -125,11 +125,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -137,11 +137,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -149,11 +149,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -161,11 +161,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -173,11 +173,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -185,11 +185,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -197,11 +197,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*BUG*)
@@ -213,14 +213,14 @@ let z = 3;;
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": int
-    "y": int
-    "z": int |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  int
+    "y":  int
+    "z":  int |}]
 ;;
 
 let%expect_test "zero" =
@@ -228,11 +228,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -240,11 +240,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": string
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  string
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -252,11 +252,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int  * int  * int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int *  int *  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -270,11 +270,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": char
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  char
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -291,11 +291,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -303,11 +303,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int -> int -> int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int->  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*ALL "LET" ITEMS*)
@@ -317,11 +317,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "y": int |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "y":  int |}]
 ;;
 
 let%expect_test "zero" =
@@ -329,11 +329,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "y": string  * string |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "y":  string *  string |}]
 ;;
 
 let%expect_test "zero" =
@@ -341,12 +341,12 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": int  * int
-    "y": string  * string |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  int *  int
+    "y":  string *  string |}]
 ;;
 
 let%expect_test "zero" =
@@ -354,14 +354,14 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "f": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": int
-    "y": int
-    "z": string  * string |}]
+    "f":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  int
+    "y":  int
+    "z":  string *  string |}]
 ;;
 
 let%expect_test "zero" =
@@ -369,12 +369,12 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": int
-    "y": char |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  int
+    "y":  char |}]
 ;;
 
 let%expect_test "zero" =
@@ -382,11 +382,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": bool |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  bool |}]
 ;;
 
 let%expect_test "zero" =
@@ -394,11 +394,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -407,10 +407,10 @@ let%expect_test "zero" =
     {|
     res:
     "f": 'b-> 'c
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -419,10 +419,10 @@ let%expect_test "zero" =
     {|
     res:
     "f": [ 0; ]. 'a-> 'a
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 let%expect_test "zero" =
@@ -432,18 +432,18 @@ let 5 = x;;|};
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "x": int |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "x":  int |}]
 ;;
 
 let%expect_test "zero" =
   parse_and_infer_result {|
 let x = (6: char);;|};
   [%expect {|
-    Unification_failed: int  # char |}]
+    Unification_failed:  int #  char |}]
 ;;
 
 let%expect_test "zero" =
@@ -452,11 +452,11 @@ let%expect_test "zero" =
   [%expect
     {|
     res:
-    "-": bool
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "-":  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*bug*)
@@ -466,10 +466,10 @@ let () = print_int 5;;|};
   [%expect
     {|
     res:
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*BUG*)
@@ -478,28 +478,65 @@ let%expect_test "zero" =
     {|
 let rec meven n = if n = 0 then 1 else modd (n - 1)
    and modd n = if n = 0 then 1 else meven (n - 1)
-   and homka n = damir 4
-   and damir n = homka 5
 ;;|};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
+  [%expect
+    {|
+    res:
+    "meven":  int->  int
+    "modd":  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
 
-  (Failure abobiks)
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
-  Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 720, characters 2-40
-  Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 477, characters 2-189
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+let%expect_test "zero" =
+  parse_and_infer_result {| let f (x: int) = x + x;;|};
+  [%expect
+    {|
+    res:
+    "f":  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
+
+let%expect_test "zero" =
+  parse_and_infer_result {| let f (x: int)(y: int) = x + y;;|};
+  [%expect
+    {|
+    res:
+    "f":  int->  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
+
+let%expect_test "zero" =
+  parse_and_infer_result {| let f (x: int) = x || x;;|};
+  [%expect {|
+    Unification_failed:  int #  bool |}]
+;;
+
+let%expect_test "zero" =
+  parse_and_infer_result {| let f (x: int) = function 5 -> true | 6 -> false;;|};
+  [%expect
+    {|
+    res:
+    "f":  int->  bool
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
+
+(*BUG*)
+let%expect_test "zero" =
+  parse_and_infer_result {| let (f: int -> bool) = function 5 -> true | 6 -> false;;|};
+  [%expect {|
+    Unification_failed:  bool #  int->  bool |}]
 ;;
 
 (*KAKADU TYPE BEAT*)
@@ -510,11 +547,11 @@ let rec fac n = if n<=1 then 1 else n * fac (n-1);;|};
   [%expect
     {|
     res:
-    "fac": int -> int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fac":  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*passed*)
@@ -528,12 +565,12 @@ let rec fac n = if n<=1 then 1 else n * fac (n-1);;
   [%expect
     {|
     res:
-    "fac": int -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fac":  int->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -546,11 +583,11 @@ let rec fac_cps n k =
   [%expect
     {|
     res:
-    "fac_cps": int -> (int -> 'i) -> 'i
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fac_cps":  int-> ( int-> 'i) -> 'i
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*passed*)
@@ -565,12 +602,12 @@ let rec fac_cps n k =
   [%expect
     {|
     res:
-    "fac_cps": int -> (int -> int ) -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fac_cps":  int-> ( int->  int) ->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -590,12 +627,12 @@ let rec fib_acc a b n =
   [%expect
     {|
     res:
-    "fib": int -> int
-    "fib_acc": int -> int -> int -> int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fib":  int->  int
+    "fib_acc":  int->  int->  int->  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*passed*)
@@ -619,13 +656,13 @@ let rec fib_acc a b n =
   [%expect
     {|
     res:
-    "fib": int -> int
-    "fib_acc": int -> int -> int -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fib":  int->  int
+    "fib_acc":  int->  int->  int->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -653,13 +690,13 @@ let main =
   [%expect
     {|
     res:
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit
-    "test10": int -> int -> int -> int -> int -> int -> int -> int -> int -> int -> int
-    "test3": int -> int -> int -> int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "test10":  int->  int->  int->  int->  int->  int->  int->  int->  int->  int->  int
+    "test3":  int->  int->  int->  int
     "wrap": [ 0; ]. 'a-> 'a |}]
 ;;
 
@@ -673,12 +710,12 @@ let fac self n = if n<=1 then 1 else n * self (n-1);;|};
   [%expect
     {|
     res:
-    "fac": (int -> int ) -> int -> int
+    "fac": ( int->  int) ->  int->  int
     "fix": (('c-> 'f) -> 'c-> 'f) -> 'c-> 'f
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -695,13 +732,13 @@ let main =
   [%expect
     {|
     res:
-    "fac": (int -> int ) -> int -> int
-    "fix": ((int -> int ) -> int -> int ) -> int -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "fac": ( int->  int) ->  int->  int
+    "fix": (( int->  int) ->  int->  int) ->  int->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED?*)
@@ -715,12 +752,12 @@ let%expect_test "006" =
   [%expect
     {|
     res:
-    "foo": int -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "foo":  int->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -741,12 +778,12 @@ let main =
   [%expect
     {|
     res:
-    "foo": int -> int -> int -> int
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "foo":  int->  int->  int->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -763,12 +800,12 @@ let main =
   [%expect
     {|
     res:
-    "foo": int -> int -> int -> unit
-    "main": int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "foo":  int->  int->  int->  unit
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
 (*PASSED*)
@@ -784,24 +821,145 @@ let main =
   [%expect
     {|
     res:
-    "_start": unit -> unit -> int -> unit -> int -> int -> unit -> int -> int -> int
-    "main": unit
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "_start":  unit->  unit->  int->  unit->  int->  int->  unit->  int->  int->  int
+    "main":  unit
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
 ;;
 
-(*FAILED*)
+(*PASSED*)
 let%expect_test "008" =
-  parse_and_infer_result {|
-let addi = fun f g x -> (f x (g x: bool) : int);;|};
+  parse_and_infer_result
+    {|
+let addi = fun f g x -> (f x (g x: bool) : int);;
+let main =
+  let () = print_int (addi (fun x b -> if b then x+1 else x*2) (fun _start -> _start/2 = 0) 4) in
+  0;;|};
   [%expect
     {|
     res:
-    "addi": [ 2; ]. ('c-> bool -> int ) -> ('c-> bool ) -> 'c-> int
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
+    "addi": [ 2; ]. ('c->  bool->  int) -> ('c->  bool) -> 'c->  int
+    "main":  int
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
+
+(*PASSED*)
+let%expect_test "009" =
+  parse_and_infer_result {|
+let temp =
+  let f = fun x -> x in
+  (f 1, f true);;|};
+  [%expect
+    {|
+    res:
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit
+    "temp":  int *  bool |}]
+;;
+
+(*FAILED _5*)
+let%expect_test "010" =
+  parse_and_infer_result
+    {|
+let _1 = fun x y (a, _) -> (x + y - a) = 1;;
+let _2 =
+    let x, Some f = 1, Some ( "p1onerka was here" )
+    in x;;
+    let _3 =  Some (1, "hi");;
+    let _4 = let rec f x = f 5 in f;;
+ let id1, id2 = let id x = x in (id, id);;
+    |};
+  [%expect
+    {|
+    res:
+    "_1": [ 3; ].  int->  int->  int * 'd->  bool
+    "_2":  int
+    "_3":  int *  string option
+    "_4": [ 12; ].  int-> 'b
+    "id1": [ 16; 17; ]. 'b-> 'b
+    "id2": [ 16; 17; ]. 'b-> 'b
+    "print_bool":  bool->  unit
+    "print_char":  char->  unit
+    "print_endline":  string->  unit
+    "print_int":  int->  unit |}]
+;;
+
+let _42 = function
+  | 42 -> true
+  | _ -> false
+;;
+
+let int_of_option = function
+  | Some x -> x
+  | None -> 0
+;;
+
+let _6 arg =
+  match arg with
+  | Some x ->
+    let y = x in
+    y
+;;
+
+let _5 =
+  let id x = x in
+  match Some id with
+  | Some f ->
+    let _ = f "42" in
+    f 42
+  | None -> 0
+;;
+
+(*FAILED _5*)
+let%expect_test "010" =
+  parse_and_infer_result
+    {|
+let rec fix f x = f (fix f) x;;
+let map f p = let (a,b) = p in (f a, f b);;
+let fixpoly l =
+  fix (fun self l -> map (fun li x -> li (self l) x) l) l;;
+let feven p n =
+  let (e, o) = p in
+  if n = 0 then 1 else o (n - 1);;
+let fodd p n =
+  let (e, o) = p in
+  if n = 0 then 0 else e (n - 1);;
+let tie = fixpoly (feven, fodd);;
+
+let rec meven n = if n = 0 then 1 else modd (n - 1)
+and modd n = if n = 0 then 1 else meven (n - 1);;
+let main =
+  let () = print_int (modd 1) in
+  let () = print_int (meven 2) in
+  let (even,odd) = tie in
+  let () = print_int (odd 3) in
+  let () = print_int (even 4) in
+  0;;|};
+  [%expect.unreachable]
+[@@expect.uncaught_exn {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
+
+  (Failure aboba)
+  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+  Called from Ocamladt_lib__Infer.infer_exp in file "lib/infer.ml", line 410, characters 13-29
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 719, characters 2-40
+  Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 922, characters 2-638
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;

--- a/OcamlADT/tests/infer.ml
+++ b/OcamlADT/tests/infer.ml
@@ -1169,8 +1169,7 @@ let%expect_test "ADT of few" =
 let x = 10;;
 let Circle (5,5) = Circle 5;;
 |};
-  [%expect {|
-    Unification_failed: int # int * int |}]
+  [%expect {| Unification_failed: int # int * int |}]
 ;;
 
 let%expect_test "ADT with poly" =
@@ -1229,7 +1228,8 @@ let%expect_test "ADT with poly3" =
   | Square of int * 'a * 'a
 ;;
 |};
-  [%expect{|
+  [%expect
+    {|
     res:
     "Circle": int -> '0 shape
     "Rectangle": char * int -> '0 shape
@@ -1239,4 +1239,40 @@ let%expect_test "ADT with poly3" =
     "print_char": char -> unit
     "print_endline": string -> unit
     "print_int": int -> unit |}]
+;;
+
+let%expect_test "ADT with poly constraint" =
+  parse_and_infer_result
+    {|
+  type 'a shape = Circle of int
+  | Rectangle of char * int
+  | Square of int * 'a * 'a
+;;
+let (x: shape) = Circle 5;;
+|};
+  [%expect {|
+    Unification_failed: '0 shape # shape |}]
+;;
+
+let%expect_test "ADT with constraint" =
+  parse_and_infer_result
+    {|
+  type 'a shape = Circle of int
+  | Rectangle of char * int
+  | Square of int * 'a * 'a
+;;
+let (x: (int->int) shape) = Circle 5;;
+|};
+  [%expect
+    {|
+    res:
+    "Circle": int -> (int -> int) shape
+    "Rectangle": char * int -> (int -> int) shape
+    "Square": int * 'a * 'a -> (int -> int) shape
+    "a": int -> int
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": (int -> int) shape |}]
 ;;

--- a/OcamlADT/tests/infer.ml
+++ b/OcamlADT/tests/infer.ml
@@ -1040,7 +1040,7 @@ let%expect_test "015" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 817, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 821, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
   Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1030, characters 2-52
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
@@ -1092,7 +1092,7 @@ let%expect_test "098" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 817, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 821, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
   Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1082, characters 2-48
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]

--- a/OcamlADT/tests/infer.ml
+++ b/OcamlADT/tests/infer.ml
@@ -196,7 +196,8 @@ let%expect_test "zero" =
 let homka = Some id in
 match homka with
 | Some f -> f 42, f "42";;|};
-  [%expect{|
+  [%expect
+    {|
     res:
     "-": int * string
     "print_bool": bool -> unit
@@ -211,7 +212,8 @@ let%expect_test "zero" =
 let homkaOBOLTUS = id in
 match homkaOBOLTUS with
 |  f -> f 42, f "42";;|};
-  [%expect{|
+  [%expect
+    {|
     res:
     "-": int * string
     "print_bool": bool -> unit
@@ -226,7 +228,7 @@ let%expect_test "zero" =
   let homkaOBOLTIMUSPRIME = id in
   match homkaOBOLTIMUSPRIME with
   |  f -> f 42, f "42";;|};
-  [%expect{|
+  [%expect {|
     Unification_failed: int # string |}]
 ;;
 
@@ -293,7 +295,8 @@ let%expect_test "zero" =
 | 68 -> 'h' 
 | 69 -> 's' 
 | 89 -> 'a';;|};
-  [%expect{|
+  [%expect
+    {|
     res:
     "-": char
     "print_bool": bool -> unit
@@ -313,7 +316,8 @@ let%expect_test "zero" =
 |7 -> 1
 | _ -> 3
 ;;|};
-  [%expect{|
+  [%expect
+    {|
     res:
     "-": int
     "print_bool": bool -> unit
@@ -548,7 +552,8 @@ let%expect_test "zero" =
 
 let%expect_test "zero" =
   parse_and_infer_result {| let f (x: int) = function 5 -> true | 6 -> false;;|};
-  [%expect{|
+  [%expect
+    {|
     res:
     "f": int -> bool
     "print_bool": bool -> unit
@@ -562,10 +567,11 @@ let%expect_test "zero" =
   [%expect {|
     Unbound_variable: "f" |}]
 ;;
+
 (*BUG*)
 let%expect_test "zero" =
   parse_and_infer_result {| let (f: int -> bool) = function 5 -> true | 6 -> false;;|};
-  [%expect{|
+  [%expect {|
     Unification_failed: bool # int -> bool |}]
 ;;
 
@@ -610,8 +616,7 @@ let%expect_test "002fact without builtin" =
 let rec fac_cps n k =
   if n=1 then k 1 else
   fac_cps (n-1) (fun p -> k (p*n));;|};
-  [%expect
-    {|
+  [%expect {|
     Occurs_check |}]
 ;;
 
@@ -624,8 +629,7 @@ let rec fac_cps n k =
   fac_cps (n-1) (fun p -> k (p*n));; let main =
   let () = print_int (fac_cps 4 (fun print_int -> print_int)) in
   0;;|};
-  [%expect
-    {|
+  [%expect {|
     Occurs_check |}]
 ;;
 
@@ -916,24 +920,30 @@ let aaa_5 =
   | None -> 0
 ;;
     |};
-  [%expect{|
-    res:
-    "_1": [ 3; ]. int -> int -> int * '3 -> bool
-    "_2": int
-    "_3": int * stringoption
-    "_4": [ 13; ]. int -> '13
-    "a_42": bool
-    "aaa_5": int
-    "id1": [ 17; 18; ]. '17 -> '17
-    "id2": [ 17; 18; ]. '18 -> '18
-    "int_of_option": int
-    "k_6": [ 31; ]. '31option -> '31
-    "print_bool": bool -> unit
-    "print_char": char -> unit
-    "print_endline": string -> unit
-    "print_int": int -> unit |}]
-;;
+  [%expect.unreachable]
+[@@expect.uncaught_exn
+  {|
+  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
+     This is strongly discouraged as backtraces are fragile.
+     Please change this test to not include a backtrace. *)
 
+  (Failure noname)
+  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
+  Called from Ocamladt_lib__Infer.infer_pat in file "lib/infer.ml", line 312, characters 16-33
+  Called from Ocamladt_lib__Infer.infer_exp.(fun) in file "lib/infer.ml", line 584, characters 34-65
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
+  Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 902, characters 2-40
+  Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 892, characters 2-560
+  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+;;
 
 (*FAILED *)
 let%expect_test "015" =
@@ -960,7 +970,8 @@ let main =
   let () = print_int (even 4) in
   0;;
 |};
-  [%expect{|
+  [%expect
+    {|
     res:
     "feven": [ 32; ]. '32 * (int -> int) -> int -> int
     "fix": [ 2; 5; ]. (('2 -> '5) -> '2 -> '5) -> '2 -> '5
@@ -977,7 +988,6 @@ let main =
     "tie": (int -> int) * (int -> int) |}]
 ;;
 
-  
 (*KAKADU DO NOT TYPE BEAT*)
 
 (*PASSED*)
@@ -1021,11 +1031,11 @@ let%expect_test "005  " =
 let _2 = function
   | Some f -> let _ = f "42" in f 42
   | None -> 1;;|};
-  [%expect{|
+  [%expect {|
     Unification_failed: string # int |}]
 ;;
 
-(*PASSED*)
+(*FAILED*)
 let%expect_test "015" =
   parse_and_infer_result {|let rec (a,b) = (a,b);;|};
   [%expect.unreachable]
@@ -1040,9 +1050,9 @@ let%expect_test "015" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 821, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 902, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1030, characters 2-52
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1040, characters 2-52
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1066,7 +1076,7 @@ let%expect_test "091.1" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 58, characters 8-25
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1058, characters 2-53
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1068, characters 2-53
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1081,7 +1091,8 @@ let%expect_test "097.2" =
 let%expect_test "098" =
   parse_and_infer_result {|let rec x = x + 1;;|};
   [%expect.unreachable]
-[@@expect.uncaught_exn {|
+[@@expect.uncaught_exn
+  {|
   (* CR expect_test_collector: This test expectation appears to contain a backtrace.
      This is strongly discouraged as backtraces are fragile.
      Please change this test to not include a backtrace. *)
@@ -1092,9 +1103,9 @@ let%expect_test "098" =
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.(>>=) in file "lib/infer.ml", line 11, characters 18-22
   Called from Ocamladt_lib__Infer.MInfer.run in file "lib/infer.ml" (inlined), line 60, characters 18-23
-  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 821, characters 2-40
+  Called from Ocamladt_lib__Infer.run_infer_program.(fun) in file "lib/infer.ml", line 902, characters 2-40
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 60, characters 11-52
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1082, characters 2-48
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1092, characters 2-48
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1110,6 +1121,122 @@ let%expect_test "098" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Infer.parse_and_infer_result in file "tests/infer.ml", line 58, characters 8-25
-  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1102, characters 2-50
+  Called from Ocamladt_tests__Infer.(fun) in file "tests/infer.ml", line 1113, characters 2-50
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+;;
+
+(*ADT*)
+let%expect_test "Simplest ADT" =
+  parse_and_infer_result {|
+  type shape = Circle ;;
+|};
+  [%expect
+    {|
+    res:
+    "Circle": shape
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
+;;
+
+let%expect_test "ADT of" =
+  parse_and_infer_result
+    {|
+  type shape = Circle of int ;;
+  type ('a,'b) koka = Circle of int ;;
+|};
+  [%expect
+    {|
+    res:
+    "Circle": int -> '2 * '1 koka
+    "a": '2
+    "b": '1
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
+;;
+
+let%expect_test "ADT of few" =
+  parse_and_infer_result
+    {|
+  type shape = 
+  Circle of int
+| Rectangle of float 
+| Triangle of int*int
+;;
+let x = 10;;
+let Circle (5,5) = Circle 5;;
+|};
+  [%expect {|
+    Unification_failed: int # int * int |}]
+;;
+
+let%expect_test "ADT with poly" =
+  parse_and_infer_result
+    {|
+  type 'a shape = Circle of int
+  | Rectangle of int * int
+  | Square of int
+;;
+let x = 10;;
+let Circle 5 = Circle 5;;
+|};
+  [%expect
+    {|
+    res:
+    "Circle": int -> '0 shape
+    "Rectangle": int * int -> '0 shape
+    "Square": int -> '0 shape
+    "a": '0
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int |}]
+;;
+
+let%expect_test "ADT with poly2" =
+  parse_and_infer_result
+    {|
+  type 'a shape = Circle of int
+  | Rectangle of 'a * int
+  | Square of int
+;;
+let x = 10;;
+let Rectangle ('c',5) = Circle 5;;
+|};
+  [%expect
+    {|
+    res:
+    "Circle": int -> '0 shape
+    "Rectangle": char * int -> '0 shape
+    "Square": int -> '0 shape
+    "a": '0
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit
+    "x": int |}]
+;;
+
+let%expect_test "ADT with poly3" =
+  parse_and_infer_result
+    {|
+  type 'a shape = Circle of int
+  | Rectangle of char * int
+  | Square of int * 'a * 'a
+;;
+|};
+  [%expect{|
+    res:
+    "Circle": int -> '0 shape
+    "Rectangle": char * int -> '0 shape
+    "Square": int * 'a * 'a -> '0 shape
+    "a": '0
+    "print_bool": bool -> unit
+    "print_char": char -> unit
+    "print_endline": string -> unit
+    "print_int": int -> unit |}]
 ;;

--- a/OcamlADT/tests/interpreter.ml
+++ b/OcamlADT/tests/interpreter.ml
@@ -491,7 +491,7 @@ type shape = Point of int
   | Rect of int * int * int 
 ;;
 |};
-  [%expect {| |}]
+  [%expect{||}]
 ;;
 
 (*we dont support regular custom types*)
@@ -527,9 +527,9 @@ print_int y
 ;;
 
   |};
-  [%expect {|
+  [%expect{|
     3
-    val area = <fun>|}]
+    val area = <fun> |}]
 ;;
 
 let%expect_test "simple adt with pattern matching function (else case) + printing" =
@@ -550,9 +550,9 @@ let y = area x in
 print_int y
 ;;
   |};
-  [%expect {|
+  [%expect{|
     10
-    val area = <fun>|}]
+    val area = <fun> |}]
 ;;
 
 let%expect_test "simple adt with pattern matching + printing v2" =
@@ -573,9 +573,9 @@ let y = area x in
 print_int y
 ;;
   |};
-  [%expect {|
+  [%expect{|
     10
-    val area = <fun>|}]
+    val area = <fun> |}]
 ;;
 
 let%expect_test "simple adt with pattern matching + printing v3" =
@@ -596,9 +596,9 @@ let y = area x in
 print_int y
 ;;
   |};
-  [%expect {|
+  [%expect{|
     50
-    val area = <fun>|}]
+    val area = <fun> |}]
 ;;
 
 let%expect_test "simple adt (fail: UnboundValue)" =
@@ -612,8 +612,7 @@ type shape = Circle of int
 let x = Chto 5
 ;;
   |};
-  [%expect {|
-    Intepreter error: Unbound value Chto|}]
+  [%expect{| Intepreter error: Unbound value Chto |}]
 ;;
 
 let%expect_test "simple adt with pattern matching (fail: PatternMismatch)" =
@@ -634,9 +633,9 @@ let y = area x in
 print_int y
 ;;
   |};
-  [%expect {|
+  [%expect{|
     10
-    val area = <fun>|}]
+    val area = <fun> |}]
 ;;
 
 let%expect_test "simple adt (fail: UnboundValue Cir)" =
@@ -649,7 +648,7 @@ type shape = Circle of int
 let x = Cir 5 in 
 print_int area x;;
   |};
-  [%expect {| Intepreter error: Unbound value Cir|}]
+  [%expect{| Intepreter error: Unbound value Cir |}]
 ;;
 
 (* good, needs a initialization check + infer print(see next tests)*)
@@ -659,7 +658,7 @@ type 'a tree = Leaf
   | Node of 'a * 'a tree * 'a tree
 ;;
   |};
-  [%expect {| |}]
+  [%expect{||}]
 ;;
 
 let%expect_test "poly adt tree (dumb insert)" =
@@ -687,8 +686,7 @@ let rec tree_size t =
 let () = print_int (tree_size tree1)
 
   |};
-  [%expect
-    {|
+  [%expect{|
     1
     val insert = <fun>
     val tree1 = <ADT>: Node
@@ -718,8 +716,7 @@ let rec tree_size t =
 let () = print_int (tree_size tree2)
 
   |};
-  [%expect
-    {|
+  [%expect{|
     0
     val insert = <fun>
     val tree2 = <ADT>: Leaf
@@ -754,8 +751,7 @@ let rec tree_size t =
 let () = print_int (tree_size tree)
 
   |};
-  [%expect
-    {|
+  [%expect{|
     4
     val insert = <fun>
     val tree = <ADT>: Node
@@ -784,7 +780,7 @@ let rec tree_size t =
 let () = print_int (tree_size tree)
 
   |};
-  [%expect {|
+  [%expect{|
     4
     val tree = <ADT>: Node
     val tree_size = <fun> |}]

--- a/OcamlADT/tests/interpreter.ml
+++ b/OcamlADT/tests/interpreter.ml
@@ -179,6 +179,7 @@ let%expect_test "multiple let bool assignments" =
 let%expect_test "fun assignment with bool operators" =
   pp_parse_demo {| let id = fun x y -> x && y in print_bool (id true false) ;; |};
   [%expect {| false |}]
+
 ;;
 
 let%expect_test "fun assignment with bool operators (tuple arg)" =

--- a/OcamlADT/tests/parser.ml
+++ b/OcamlADT/tests/parser.ml
@@ -1589,9 +1589,7 @@ let%expect_test "keyword" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1581, characters 2-44
-
+  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1581, characters 2-45
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1703,6 +1701,25 @@ print_int y
                 []),
                (Exp_apply ((Exp_ident "print_int"), (Exp_ident "y")))))
             )))
+      ]|}]
+;;
+
+let%expect_test "simple adt with pattern matching function + printing v3" =
+  test_program
+    {|
+type ('a,'b) shape = Circle of int
+  | Rectangle of int * int
+  | Square of 'a * 'b
+;;
+  |};
+  [%expect
+    {|
+    [(Str_adt (["a"; "b"], "shape",
+        (("Circle", [(Type_construct ("int", []))]),
+         [("Rectangle",
+           [(Type_construct ("int", [])); (Type_construct ("int", []))]);
+           ("Square", [(Type_var "a"); (Type_var "b")])])
+        ))
       ]|}]
 ;;
 
@@ -1847,7 +1864,7 @@ let x = [];;
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1834, characters 2-70
+  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1854, characters 2-35
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1981,5 +1998,5 @@ let fodd p n =
               [])
              ))
           ] |}]
-    
+     
     

--- a/OcamlADT/tests/parser.ml
+++ b/OcamlADT/tests/parser.ml
@@ -1704,6 +1704,7 @@ print_int y
       ]|}]
 ;;
 
+
 let%expect_test "function assignment with bool operators" =
   test_program {| let id = fun (x, y) -> x && y in print_bool (id true false) ;; |};
   [%expect
@@ -1847,3 +1848,4 @@ let x = [];;
   Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1834, characters 2-70
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
+

--- a/OcamlADT/tests/parser.ml
+++ b/OcamlADT/tests/parser.ml
@@ -1000,19 +1000,16 @@ let%expect_test "_" =
 
 (*good*)
 let%expect_test "_" =
-  test_program {|(f : (Int -> int -> int));;|};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Failure ": end_of_input")
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1003, characters 2-46
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+  test_program {|(f : (int -> int -> int));;|};
+  [%expect{|
+    [(Str_eval
+        (Exp_constraint ((Exp_ident "f"),
+           (Type_arrow (
+              (Type_arrow ((Type_construct ("int", [])),
+                 (Type_construct ("int", [])))),
+              (Type_construct ("int", []))))
+           )))
+      ] |}]
 ;;
 
 let%expect_test "_" =
@@ -1057,19 +1054,29 @@ let%expect_test "_" =
 (*good*)
 let%expect_test "_" =
   test_program
-    {|('v' : (SqEcf8boz* L58r6D_P_bX___yy_93GPH__04_r___d9Zc_1U2__c8XmN1n_F_WBqxl68h_8_TCGqp3B_5w_Y_53a6_d_6_H9845__c5__09s* Sh__7ud_43* E_KKm_z3r5__jHMLw_qd1760R_G__nI6_J040__AB_6s0__D__d__e32Te6H_4__Ec_V_E__f_* o0_a_W_* f__LcPREH13__mY_CezffoI5_8_u_zU__ZncOnf_v4_L8_44Y72_3_A5_B758TViP_u_vyFU9_1* QD0* g4wp33A_W* E1V_gi_6y* x_Sv_PZ)) ;; |};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Failure ": end_of_input")
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1059, characters 2-356
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+    {|('v' : (sqEcf8boz* s58r6D_P_bX___yy_93GPH__04_r___d9Zc_1U2__c8XmN1n_F_WBqxl68h_8_TCGqp3B_5w_Y_53a6_d_6_H9845__c5__09s* sh__7ud_43* s_KKm_z3r5__jHMLw_qd1760R_G__nI6_J040__AB_6s0__D__d__e32Te6H_4__Ec_V_E__f_* o0_a_W_* f__LcPREH13__mY_CezffoI5_8_u_zU__ZncOnf_v4_L8_44Y72_3_A5_B758TViP_u_vyFU9_1* qD0* g4wp33A_W* e1V_gi_6y* x_Sv_PZ)) ;; |};
+  [%expect{|
+    [(Str_eval
+        (Exp_constraint ((Exp_constant (Const_char 'v')),
+           (Type_tuple
+              ((Type_construct ("sqEcf8boz", [])),
+               (Type_construct (
+                  "s58r6D_P_bX___yy_93GPH__04_r___d9Zc_1U2__c8XmN1n_F_WBqxl68h_8_TCGqp3B_5w_Y_53a6_d_6_H9845__c5__09s",
+                  [])),
+               [(Type_construct ("sh__7ud_43", []));
+                 (Type_construct (
+                    "s_KKm_z3r5__jHMLw_qd1760R_G__nI6_J040__AB_6s0__D__d__e32Te6H_4__Ec_V_E__f_",
+                    []));
+                 (Type_construct ("o0_a_W_", []));
+                 (Type_construct (
+                    "f__LcPREH13__mY_CezffoI5_8_u_zU__ZncOnf_v4_L8_44Y72_3_A5_B758TViP_u_vyFU9_1",
+                    []));
+                 (Type_construct ("qD0", []));
+                 (Type_construct ("g4wp33A_W", []));
+                 (Type_construct ("e1V_gi_6y", []));
+                 (Type_construct ("x_Sv_PZ", []))]))
+           )))
+      ] |}]
 ;;
 
 let%expect_test "not keyword" =
@@ -1089,8 +1096,7 @@ let%expect_test "adt v0" =
 
 let%expect_test "adt v1" =
   test_program {|type shape = Circle | Square of int;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt ([], "shape",
         (("Circle", []), [("Square", [(Type_construct ("int", []))])])))
       ] |}]
@@ -1104,8 +1110,7 @@ let%expect_test "adt v2" =
 
 let%expect_test "adt v3" =
   test_program {|type shape = Circle | Square of int * int;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt ([], "shape",
         (("Circle", []),
          [("Square", [(Type_construct ("int", [])); (Type_construct ("int", []))])
@@ -1116,8 +1121,7 @@ let%expect_test "adt v3" =
 
 let%expect_test "adt with poly" =
   test_program {|type 'a shape = Circle | Square of 'a * 'a ;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "shape",
         (("Circle", []), [("Square", [(Type_var "a"); (Type_var "a")])])))
       ] |}]
@@ -1125,16 +1129,14 @@ let%expect_test "adt with poly" =
 
 let%expect_test "bad adt with poly (wrong types)" =
   test_program {|type 'a shape = Circle | Square of 'b;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "shape", (("Circle", []), [("Square", [(Type_var "b")])])))
       ] |}]
 ;;
 
 let%expect_test "adt with poly (not poly in variant)" =
   test_program {|type 'a shape = Circle | Square of int;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "shape",
         (("Circle", []), [("Square", [(Type_construct ("int", []))])])))
       ] |}]
@@ -1147,8 +1149,7 @@ let%expect_test "adt with poly v.easy" =
 
 let%expect_test "adt with multiple poly v1" =
   test_program {|type ('a, 'b) shape = Circle | Square of 'a;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"; "b"], "shape",
         (("Circle", []), [("Square", [(Type_var "a")])])))
       ] |}]
@@ -1156,8 +1157,7 @@ let%expect_test "adt with multiple poly v1" =
 
 let%expect_test "adt with multiple poly v2" =
   test_program {|type ('a, 'b) shape = Circle | Square of ('a,'b) shape;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"; "b"], "shape",
         (("Circle", []),
          [("Square",
@@ -1231,8 +1231,7 @@ let%expect_test "match case" =
 
 let%expect_test "adt with tuple in variant" =
   test_program {|type shape = Circle | Square of int * int ;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt ([], "shape",
         (("Circle", []),
          [("Square", [(Type_construct ("int", [])); (Type_construct ("int", []))])
@@ -1243,8 +1242,7 @@ let%expect_test "adt with tuple in variant" =
 
 let%expect_test "adt with recursive poly variant" =
   test_program {|type ('a, 'b) shape = Circle | Square of 'a shape;;|};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"; "b"], "shape",
         (("Circle", []),
          [("Square", [(Type_construct ("shape", [(Type_var "a")]))])])
@@ -1256,8 +1254,7 @@ let%expect_test "adt list" =
   test_program {|
 type 'a my_list = Nil | Cons of 'a * 'a my_list;;
 |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "my_list",
         (("Nil", []),
          [("Cons",
@@ -1274,8 +1271,7 @@ type 'a nested_list = Nil
 | List of 'a nested_list;;
 
 |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "nested_list",
         (("Nil", []),
          [("Cons",
@@ -1292,8 +1288,7 @@ type 'a nested_list = Nil
 | Cons of 'a * 'a nested_list 
 | List of 'a nested_list nested_list;;
 |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "nested_list",
         (("Nil", []),
          [("Cons",
@@ -1313,8 +1308,7 @@ type 'a tree = Leaf
   | Node of 'a * 'a tree * 'a tree
 ;;
   |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "tree",
         (("Leaf", []),
          [("Node",
@@ -1322,7 +1316,7 @@ type 'a tree = Leaf
              (Type_construct ("tree", [(Type_var "a")]))])
            ])
         ))
-      ]|}]
+      ] |}]
 ;;
 
 (*bad*)
@@ -1331,18 +1325,16 @@ let%expect_test "adt list with pair" =
     {| type ('a, 'b) pair_list = Nil 
     | Cons of ('a * 'b) * ('a, 'b) pair_list;;
 |};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Failure ": end_of_input")
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1330, characters 2-102
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+  [%expect{|
+    [(Str_adt (["a"; "b"], "pair_list",
+        (("Nil", []),
+         [("Cons",
+           [(Type_construct ("",
+               [(Type_tuple ((Type_var "a"), (Type_var "b"), []))]));
+             (Type_construct ("pair_list", [(Type_var "a"); (Type_var "b")]))])
+           ])
+        ))
+      ] |}]
 ;;
 
 let%expect_test "adt list with 2 el in node" =
@@ -1350,8 +1342,7 @@ let%expect_test "adt list with 2 el in node" =
     {| type ('a, 'b) pair_list = Nil 
     | Cons of 'a * 'b * ('a, 'b) pair_list;;
 |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"; "b"], "pair_list",
         (("Nil", []),
          [("Cons",
@@ -1359,8 +1350,7 @@ let%expect_test "adt list with 2 el in node" =
              (Type_construct ("pair_list", [(Type_var "a"); (Type_var "b")]))])
            ])
         ))
-      ]
-        |}]
+      ] |}]
 ;;
 
 let%expect_test "adt" =
@@ -1371,8 +1361,7 @@ type shape = Point of int
   | Rect of int * int * int 
 ;;
 |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt ([], "shape",
         (("Point", [(Type_construct ("int", []))]),
          [("Circle", [(Type_construct ("int", [])); (Type_construct ("int", []))]);
@@ -1403,8 +1392,7 @@ print_int y
 ;;
 
   |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt ([], "shape",
         (("Circle", [(Type_construct ("int", []))]),
          [("Rectangle",
@@ -1443,7 +1431,7 @@ print_int y
                 []),
                (Exp_apply ((Exp_ident "print_int"), (Exp_ident "y")))))
             )))
-      ]|}]
+      ] |}]
 ;;
 
 let%expect_test "rec fun (pow)" =
@@ -1579,18 +1567,15 @@ let%expect_test "keyword" =
 
 let%expect_test "keyword" =
   test_program {|let (x: int option) = 20;;|};
-  [%expect.unreachable]
-[@@expect.uncaught_exn
-  {|
-  (* CR expect_test_collector: This test expectation appears to contain a backtrace.
-     This is strongly discouraged as backtraces are fragile.
-     Please change this test to not include a backtrace. *)
-
-  (Failure ": end_of_input")
-  Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
-  Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1581, characters 2-45
-  Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
+  [%expect{|
+    [(Str_value (Nonrecursive,
+        ({ pat =
+           (Pat_constraint ((Pat_var "x"),
+              (Type_construct ("option", [(Type_construct ("int", []))]))));
+           expr = (Exp_constant (Const_integer 20)) },
+         [])
+        ))
+      ] |}]
 ;;
 
 let%expect_test "keyword" =
@@ -1640,7 +1625,7 @@ let%expect_test "simple adt with pattern matching function + printing v3" =
     {|
 type 'a shape = Circle of int
   | Rectangle of int * int
-  | Square of int
+  | Square of int 
 ;;
 let area s = 
     match s with
@@ -1653,8 +1638,7 @@ let y = area x in
 print_int y
 ;;
   |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"], "shape",
         (("Circle", [(Type_construct ("int", []))]),
          [("Rectangle",
@@ -1701,7 +1685,7 @@ print_int y
                 []),
                (Exp_apply ((Exp_ident "print_int"), (Exp_ident "y")))))
             )))
-      ]|}]
+      ] |}]
 ;;
 
 let%expect_test "simple adt with pattern matching function + printing v3" =
@@ -1712,15 +1696,14 @@ type ('a,'b) shape = Circle of int
   | Square of 'a * 'b
 ;;
   |};
-  [%expect
-    {|
+  [%expect{|
     [(Str_adt (["a"; "b"], "shape",
         (("Circle", [(Type_construct ("int", []))]),
          [("Rectangle",
            [(Type_construct ("int", [])); (Type_construct ("int", []))]);
            ("Square", [(Type_var "a"); (Type_var "b")])])
         ))
-      ]|}]
+      ] |}]
 ;;
 
 
@@ -1864,7 +1847,7 @@ let x = [];;
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
-  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1854, characters 2-35
+  Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1837, characters 2-35
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 

--- a/OcamlADT/tests/parser.ml
+++ b/OcamlADT/tests/parser.ml
@@ -1849,3 +1849,135 @@ let x = [];;
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
+      let%expect_test "keyword" =
+      test_program {|let rec fix f x = f (fix f) x;;
+let map f p = let (a,b) = p in (f a, f b);;
+let fixpoly l =
+  fix (fun self l -> map (fun li x -> li (self l) x) l) l;;
+let feven p n =
+  let (e, o) = p in
+  if n = 0 then 1 else o (n - 1);;
+let fodd p n =
+  let (e, o) = p in
+  if n = 0 then 0 else e (n - 1);;
+  let tie = fixpoly (feven, fodd);; |};
+      [%expect{|
+        [(Str_value (Recursive,
+            ({ pat = (Pat_var "fix");
+               expr =
+               (Exp_fun (((Pat_var "f"), [(Pat_var "x")]),
+                  (Exp_apply (
+                     (Exp_apply ((Exp_ident "f"),
+                        (Exp_apply ((Exp_ident "fix"), (Exp_ident "f"))))),
+                     (Exp_ident "x")))
+                  ))
+               },
+             [])
+            ));
+          (Str_value (Nonrecursive,
+             ({ pat = (Pat_var "map");
+                expr =
+                (Exp_fun (((Pat_var "f"), [(Pat_var "p")]),
+                   (Exp_let (Nonrecursive,
+                      ({ pat = (Pat_tuple ((Pat_var "a"), (Pat_var "b"), []));
+                         expr = (Exp_ident "p") },
+                       []),
+                      (Exp_tuple
+                         ((Exp_apply ((Exp_ident "f"), (Exp_ident "a"))),
+                          (Exp_apply ((Exp_ident "f"), (Exp_ident "b"))), []))
+                      ))
+                   ))
+                },
+              [])
+             ));
+          (Str_value (Nonrecursive,
+             ({ pat = (Pat_var "fixpoly");
+                expr =
+                (Exp_fun (((Pat_var "l"), []),
+                   (Exp_apply (
+                      (Exp_apply ((Exp_ident "fix"),
+                         (Exp_fun (((Pat_var "self"), [(Pat_var "l")]),
+                            (Exp_apply (
+                               (Exp_apply ((Exp_ident "map"),
+                                  (Exp_fun (((Pat_var "li"), [(Pat_var "x")]),
+                                     (Exp_apply (
+                                        (Exp_apply ((Exp_ident "li"),
+                                           (Exp_apply ((Exp_ident "self"),
+                                              (Exp_ident "l")))
+                                           )),
+                                        (Exp_ident "x")))
+                                     ))
+                                  )),
+                               (Exp_ident "l")))
+                            ))
+                         )),
+                      (Exp_ident "l")))
+                   ))
+                },
+              [])
+             ));
+          (Str_value (Nonrecursive,
+             ({ pat = (Pat_var "feven");
+                expr =
+                (Exp_fun (((Pat_var "p"), [(Pat_var "n")]),
+                   (Exp_let (Nonrecursive,
+                      ({ pat = (Pat_tuple ((Pat_var "e"), (Pat_var "o"), []));
+                         expr = (Exp_ident "p") },
+                       []),
+                      (Exp_if (
+                         (Exp_apply ((Exp_ident "="),
+                            (Exp_tuple
+                               ((Exp_ident "n"), (Exp_constant (Const_integer 0)), []))
+                            )),
+                         (Exp_constant (Const_integer 1)),
+                         (Some (Exp_apply ((Exp_ident "o"),
+                                  (Exp_apply ((Exp_ident "-"),
+                                     (Exp_tuple
+                                        ((Exp_ident "n"),
+                                         (Exp_constant (Const_integer 1)), []))
+                                     ))
+                                  )))
+                         ))
+                      ))
+                   ))
+                },
+              [])
+             ));
+          (Str_value (Nonrecursive,
+             ({ pat = (Pat_var "fodd");
+                expr =
+                (Exp_fun (((Pat_var "p"), [(Pat_var "n")]),
+                   (Exp_let (Nonrecursive,
+                      ({ pat = (Pat_tuple ((Pat_var "e"), (Pat_var "o"), []));
+                         expr = (Exp_ident "p") },
+                       []),
+                      (Exp_if (
+                         (Exp_apply ((Exp_ident "="),
+                            (Exp_tuple
+                               ((Exp_ident "n"), (Exp_constant (Const_integer 0)), []))
+                            )),
+                         (Exp_constant (Const_integer 0)),
+                         (Some (Exp_apply ((Exp_ident "e"),
+                                  (Exp_apply ((Exp_ident "-"),
+                                     (Exp_tuple
+                                        ((Exp_ident "n"),
+                                         (Exp_constant (Const_integer 1)), []))
+                                     ))
+                                  )))
+                         ))
+                      ))
+                   ))
+                },
+              [])
+             ));
+          (Str_value (Nonrecursive,
+             ({ pat = (Pat_var "tie");
+                expr =
+                (Exp_apply ((Exp_ident "fixpoly"),
+                   (Exp_tuple ((Exp_ident "feven"), (Exp_ident "fodd"), []))))
+                },
+              [])
+             ))
+          ] |}]
+    
+    

--- a/OcamlADT/tests/parser.ml
+++ b/OcamlADT/tests/parser.ml
@@ -1578,7 +1578,7 @@ let%expect_test "keyword" =
 ;;
 
 let%expect_test "keyword" =
-  test_program {|let (x:int option) = 20;;|};
+  test_program {|let (x: int option) = 20;;|};
   [%expect.unreachable]
 [@@expect.uncaught_exn
   {|
@@ -1589,7 +1589,9 @@ let%expect_test "keyword" =
   (Failure ": end_of_input")
   Raised at Stdlib.failwith in file "stdlib.ml", line 29, characters 17-33
   Called from Ocamladt_tests__Parser.test_program in file "tests/parser.ml", line 9, characters 51-66
+
   Called from Ocamladt_tests__Parser.(fun) in file "tests/parser.ml", line 1581, characters 2-44
+
   Called from Expect_test_collector.Make.Instance_io.exec in file "collector/expect_test_collector.ml", line 234, characters 12-19 |}]
 ;;
 
@@ -1638,7 +1640,7 @@ let%expect_test "keyword" =
 let%expect_test "simple adt with pattern matching function + printing v3" =
   test_program
     {|
-type shape = Circle of int
+type 'a shape = Circle of int
   | Rectangle of int * int
   | Square of int
 ;;
@@ -1655,7 +1657,7 @@ print_int y
   |};
   [%expect
     {|
-    [(Str_adt ([], "shape",
+    [(Str_adt (["a"], "shape",
         (("Circle", [(Type_construct ("int", []))]),
          [("Rectangle",
            [(Type_construct ("int", [])); (Type_construct ("int", []))]);

--- a/OcamlADT/tests/repl.t
+++ b/OcamlADT/tests/repl.t
@@ -12,9 +12,6 @@
 
   $ ../bin/interpret.exe  manytests/typed/002fac.ml
   Running... 
-  24
-  val fac_cps = <fun>
-  val main = 0
 
   $ ../bin/interpret.exe  manytests/typed/003fib.ml
   Running... 
@@ -88,13 +85,13 @@
   val temp = (1, true)
 
   $ ../bin/interpret.exe manytests/typed/010sukharev.ml
-  ../repl/REPL.exe: No such file or directory
-  [127]
+  File manytests/typed/010sukharev.ml not found
+  [255]
 
   $ ../bin/interpret.exe  manytests/typed/015tuples.ml
-  ../repl/REPL.exe: No such file or directory
-  [127]
+  File manytests/typed/015tuples.ml not found
+  [255]
 
   $ ../bin/interpret.exe manytests/typed/016lists.ml
-  ../repl/REPL.exe: No such file or directory
-  [127]
+  File manytests/typed/016lists.ml not found
+  [255]


### PR DESCRIPTION
- fix types parser (now can parse `int option`, `(int,int) map`
- add adt in infer
- add correct let rec in infer
- correct pattern matching
- still have some bugs in infer
- :: [] doesn't work in parser